### PR TITLE
Cap default lazyapp in-memory cache to finite MaxEntries

### DIFF
--- a/lazyapp/app.go
+++ b/lazyapp/app.go
@@ -60,6 +60,8 @@ type App struct {
 	Dependencies *lazydeps.Scope
 }
 
+const defaultCacheMaxEntries = 1024
+
 var afterDraw = func(*lazyroutes.Scope) {}
 
 func MustSub(fsys fs.FS, dir string) func() (fs.FS, error) {
@@ -85,7 +87,7 @@ func New(config Config) *App {
 	}
 	cacheOptions := config.Cache
 	if cacheOptions.Backend == nil {
-		backend, err := inmemorycache.New(inmemorycache.Options{})
+		backend, err := inmemorycache.New(inmemorycache.Options{MaxEntries: defaultCacheMaxEntries})
 		if err != nil {
 			panic(fmt.Errorf("initialize cache backend: %w", err))
 		}

--- a/lazyapp/app_test.go
+++ b/lazyapp/app_test.go
@@ -221,6 +221,10 @@ func TestAppInitializesDefaultCache(t *testing.T) {
 	if !ok || cache != app.Cache {
 		t.Fatalf("context cache = %#v, %v; want app cache", cache, ok)
 	}
+	stats := app.Cache.Stats()
+	if stats.MaxEntries != defaultCacheMaxEntries {
+		t.Fatalf("default cache MaxEntries = %d, want %d", stats.MaxEntries, defaultCacheMaxEntries)
+	}
 	if err := app.Cache.Set("Ada", "user", 1); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
### Motivation

- The automatic in-process cache created by `lazyapp.New` previously used `inmemorycache.Options{}` which left `MaxEntries` at the zero value and effectively disabled eviction, allowing unbounded memory growth for attacker-controlled keys.
- Provide a safer default that bounds the number of cached entries while preserving the existing in-memory backend behavior.

### Description

- Add a `const defaultCacheMaxEntries = 1024` and use it when `Config.Cache.Backend` is nil by calling `inmemorycache.New(inmemorycache.Options{MaxEntries: defaultCacheMaxEntries})` in `lazyapp.New`.
- Update `TestAppInitializesDefaultCache` to assert that the default cache reports `MaxEntries == defaultCacheMaxEntries` while keeping the rest of the test behavior unchanged.
- No other semantics of the cache or eviction logic were modified; the in-memory backend still enforces eviction via its existing `MaxEntries` handling.

### Testing

- Ran `go test ./lazyapp ./lazycache/inmemorycache` and the targeted packages passed (`ok` for both packages).
- Ran `go test ./...` and the full test suite completed successfully with all packages reporting `ok` or `[no test files]` as appropriate.
- Updated unit test `TestAppInitializesDefaultCache` validates the new default cap and passed as part of the test runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a406ff4da54832890796f57c419f5b0)