### PR TITLE
Normalize telemetry request method labels

### DIFF
--- a/lazytelemetry/middlewares.go
+++ b/lazytelemetry/middlewares.go
@@ -115,7 +115,7 @@ func (middleware *middleware) Handler(next http.Handler) http.Handler {
 			slog.String("path", r.URL.Path),
 		)
 		ctx = lazymetrics.WithLabels(ctx, lazymetrics.Labels{
-			"method": r.Method,
+			"method": metricRequestMethod(r.Method),
 			"route":  "unknown",
 		})
 		if traceContext, ok := lazytracing.ParseTraceparent(r.Header.Get("traceparent"), r.Header.Get("tracestate")); ok {
@@ -193,6 +193,31 @@ func (middleware *middleware) Handler(next http.Handler) http.Handler {
 
 		next.ServeHTTP(recorder, request)
 	})
+}
+
+func metricRequestMethod(method string) string {
+	switch strings.ToUpper(strings.TrimSpace(method)) {
+	case http.MethodGet:
+		return http.MethodGet
+	case http.MethodHead:
+		return http.MethodHead
+	case http.MethodPost:
+		return http.MethodPost
+	case http.MethodPut:
+		return http.MethodPut
+	case http.MethodPatch:
+		return http.MethodPatch
+	case http.MethodDelete:
+		return http.MethodDelete
+	case http.MethodConnect:
+		return http.MethodConnect
+	case http.MethodOptions:
+		return http.MethodOptions
+	case http.MethodTrace:
+		return http.MethodTrace
+	default:
+		return "UNKNOWN"
+	}
 }
 
 func requestMetricAttributes(labels lazymetrics.Labels, status int) []attribute.KeyValue {

--- a/lazytelemetry/middlewares_test.go
+++ b/lazytelemetry/middlewares_test.go
@@ -79,6 +79,36 @@ func TestMiddlewareAddsRequestIDLoggerSpanAndMetrics(t *testing.T) {
 	}
 }
 
+func TestMiddlewareNormalizesUnknownRequestMethodsForMetrics(t *testing.T) {
+	registry := lazymetrics.NewRegistry()
+	middleware := Middleware(
+		WithMiddlewareLogger(slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil))),
+		WithMetricsRegistry(registry),
+	)
+	handler := middleware.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	for _, method := range []string{"X000001", "X000002", "x000003"} {
+		request := httptest.NewRequest(method, "/", nil)
+		response := httptest.NewRecorder()
+		handler.ServeHTTP(response, request)
+	}
+
+	snapshot := registry.Snapshot()
+	labels := lazymetrics.Labels{
+		"method":       "UNKNOWN",
+		"route":        "unknown",
+		"status_class": "2xx",
+	}
+	if got := findCounter(snapshot.Counters, "http_server_requests_total", labels); got != 3 {
+		t.Fatalf("request counter = %v, want 3", got)
+	}
+	if got := findHistogramCount(snapshot.Histograms, "http_server_request_duration_seconds", labels); got != 3 {
+		t.Fatalf("duration histogram count = %d, want 3", got)
+	}
+}
+
 func TestMiddlewareGeneratesRequestIDWhenHeaderIsInvalid(t *testing.T) {
 	middleware := Middleware(
 		WithMiddlewareLogger(slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil))),


### PR DESCRIPTION
### Motivation
- Prevent unbounded metric cardinality caused by using the raw `r.Method` (attacker-controlled) as a metric label, which allowed remote clients to create arbitrarily many counter/histogram series.
- Ensure telemetry is safe for applications that enable OTEL via environment without changing logging, tracing, or request capture behavior.

### Description
- Replace use of `r.Method` for metric labels with `metricRequestMethod(r.Method)`, which normalizes methods to the standard HTTP method names and maps unknown/custom tokens to `"UNKNOWN"` (file: `lazytelemetry/middlewares.go`).
- Add the helper function `metricRequestMethod` to implement the allowlist of standard HTTP methods and the `UNKNOWN` fallback (file: `lazytelemetry/middlewares.go`).
- Add a regression test `TestMiddlewareNormalizesUnknownRequestMethodsForMetrics` that verifies multiple distinct unknown methods aggregate into a single `UNKNOWN` metric series (file: `lazytelemetry/middlewares_test.go`).
- Preserve raw `r.Method` usage for logging, tracing, and request capture so external behavior and debugging are unaffected.

### Testing
- Ran `go test ./lazytelemetry ./lazyapp` and the targeted tests passed.
- Ran `go test ./...` and the full test suite passed without failures.
- Ran `git diff --check` and there were no whitespace or diff issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4071ed3a908328a26d86ffc75858c1)