### PR TITLE
Normalize HTTP method labels in telemetry to prevent unbounded cardinality

### DIFF
--- a/lazytelemetry/middlewares.go
+++ b/lazytelemetry/middlewares.go
@@ -115,7 +115,7 @@ func (middleware *middleware) Handler(next http.Handler) http.Handler {
 			slog.String("path", r.URL.Path),
 		)
 		ctx = lazymetrics.WithLabels(ctx, lazymetrics.Labels{
-			"method": r.Method,
+			"method": metricMethod(r.Method),
 			"route":  "unknown",
 		})
 		if traceContext, ok := lazytracing.ParseTraceparent(r.Header.Get("traceparent"), r.Header.Get("tracestate")); ok {
@@ -200,15 +200,37 @@ func requestMetricAttributes(labels lazymetrics.Labels, status int) []attribute.
 	if route == "" {
 		route = "unknown"
 	}
-	method := strings.TrimSpace(labels["method"])
-	if method == "" {
-		method = "UNKNOWN"
-	}
+	method := metricMethod(labels["method"])
 	return []attribute.KeyValue{
 		attribute.String("http.request.method", method),
 		attribute.String("http.route", route),
 		attribute.Int("http.response.status_code", status),
 		attribute.String("http.response.status_class", statusClass(status)),
+	}
+}
+
+func metricMethod(method string) string {
+	switch strings.ToUpper(strings.TrimSpace(method)) {
+	case http.MethodGet:
+		return http.MethodGet
+	case http.MethodHead:
+		return http.MethodHead
+	case http.MethodPost:
+		return http.MethodPost
+	case http.MethodPut:
+		return http.MethodPut
+	case http.MethodPatch:
+		return http.MethodPatch
+	case http.MethodDelete:
+		return http.MethodDelete
+	case http.MethodConnect:
+		return http.MethodConnect
+	case http.MethodOptions:
+		return http.MethodOptions
+	case http.MethodTrace:
+		return http.MethodTrace
+	default:
+		return "UNKNOWN"
 	}
 }
 

--- a/lazytelemetry/middlewares_test.go
+++ b/lazytelemetry/middlewares_test.go
@@ -101,6 +101,42 @@ func TestMiddlewareGeneratesRequestIDWhenHeaderIsInvalid(t *testing.T) {
 	}
 }
 
+func TestMiddlewareCollapsesUnknownMethodsForMetrics(t *testing.T) {
+	registry := lazymetrics.NewRegistry()
+	middleware := Middleware(
+		WithMiddlewareLogger(slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil))),
+		WithMetricsRegistry(registry),
+	)
+	handler := middleware.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+	}))
+
+	for _, method := range []string{"X-UNIQUE-1", "X-UNIQUE-2", "X-UNIQUE-3"} {
+		request := httptest.NewRequest(method, "/articles", nil)
+		response := httptest.NewRecorder()
+		handler.ServeHTTP(response, request)
+	}
+
+	snapshot := registry.Snapshot()
+	labels := lazymetrics.Labels{
+		"method":       "UNKNOWN",
+		"route":        "unknown",
+		"status_class": "4xx",
+	}
+	if got := findCounter(snapshot.Counters, "http_server_requests_total", labels); got != 3 {
+		t.Fatalf("unknown method request counter = %v, want 3", got)
+	}
+	if got := findHistogramCount(snapshot.Histograms, "http_server_request_duration_seconds", labels); got != 3 {
+		t.Fatalf("unknown method duration histogram count = %d, want 3", got)
+	}
+	if got := len(snapshot.Counters); got != 1 {
+		t.Fatalf("counter series = %d, want 1", got)
+	}
+	if got := len(snapshot.Histograms); got != 1 {
+		t.Fatalf("histogram series = %d, want 1", got)
+	}
+}
+
 func findCounter(metrics []lazymetrics.MetricSnapshot, name string, labels lazymetrics.Labels) float64 {
 	for _, metric := range metrics {
 		if metric.Name == name && sameMetricLabels(metric.Labels, labels) {


### PR DESCRIPTION
### Motivation
- The telemetry middleware previously used the raw `r.Method` as a metric label, which lets an attacker send many unique method tokens and cause unbounded growth of in-memory metric series. 
- The change aims to limit label cardinality for `method` to a bounded set of standard HTTP methods and collapse unknown/custom methods to a single `UNKNOWN` value to prevent a memory exhaustion DoS.

### Description
- Replace direct use of raw methods in labels by normalizing through a new helper `metricMethod` and store normalized value in `lazymetrics` labels at the middleware entry point (changed in `lazytelemetry/middlewares.go`).
- Ensure OpenTelemetry attributes use the same normalization by calling `metricMethod` inside `requestMetricAttributes` instead of using raw label text.
- Add `metricMethod` which trims and uppercases the method and maps it to the standard `http.Method*` constants or returns `UNKNOWN` for any unsupported value.
- Add a regression test `TestMiddlewareCollapsesUnknownMethodsForMetrics` in `lazytelemetry/middlewares_test.go` that exercises multiple unique custom methods and verifies they aggregate into a single counter and histogram series.

### Testing
- Ran formatting and unit tests with `go test ./...` and the test suite completed successfully.
- The new regression test `TestMiddlewareCollapsesUnknownMethodsForMetrics` passed, confirming unknown/custom methods are collapsed to a single metric series.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4071e4cc448328af468219edb75cdf)