### PR TITLE
Stream S3 uploads to avoid unbounded memory buffering

### DIFF
--- a/lazystorage/s3/s3.go
+++ b/lazystorage/s3/s3.go
@@ -2,13 +2,13 @@
 package s3
 
 import (
-	"bytes"
 	"context"
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/xml"
 	"fmt"
+	"hash"
 	"io"
 	"net/http"
 	"net/url"
@@ -21,7 +21,10 @@ import (
 	"golazy.dev/lazystorage"
 )
 
-const service = "s3"
+const (
+	service         = "s3"
+	unsignedPayload = "UNSIGNED-PAYLOAD"
+)
 
 // Storage stores objects in an S3-compatible bucket.
 type Storage struct {
@@ -130,11 +133,6 @@ func (s *Storage) Put(ctx context.Context, key string, body io.Reader, options .
 	if body == nil {
 		return lazystorage.Info{}, options, fmt.Errorf("lazystorage/s3: nil body")
 	}
-	data, err := io.ReadAll(body)
-	if err != nil {
-		return lazystorage.Info{}, options, err
-	}
-
 	contentType, remaining, _ := lazystorage.Take[lazystorage.ContentType](options)
 	cacheControl, remaining, _ := lazystorage.Take[lazystorage.CacheControl](remaining)
 	disposition, remaining, _ := lazystorage.Take[lazystorage.ContentDisposition](remaining)
@@ -149,8 +147,10 @@ func (s *Storage) Put(ctx context.Context, key string, body io.Reader, options .
 	if disposition.Value != "" {
 		header.Set("Content-Disposition", disposition.Value)
 	}
+	header.Set("X-Amz-Content-Sha256", unsignedPayload)
 
-	req, err := s.newRequest(ctx, http.MethodPut, key, bytes.NewReader(data), header)
+	tracked := &hashingReader{reader: body, hash: sha256.New()}
+	req, err := s.newRequest(ctx, http.MethodPut, key, tracked, header)
 	if err != nil {
 		return lazystorage.Info{}, remaining, err
 	}
@@ -160,12 +160,11 @@ func (s *Storage) Put(ctx context.Context, key string, body io.Reader, options .
 	}
 	_ = resp.Body.Close()
 
-	hash := sha256.Sum256(data)
 	return lazystorage.Info{
 		Key:         key,
 		ContentType: contentType.Value,
-		Size:        int64(len(data)),
-		Checksum:    "sha256:" + hex.EncodeToString(hash[:]),
+		Size:        tracked.size,
+		Checksum:    "sha256:" + hex.EncodeToString(tracked.hash.Sum(nil)),
 		ModifiedAt:  time.Now().UTC(),
 	}, remaining, nil
 }
@@ -353,7 +352,10 @@ func (s *Storage) sign(req *http.Request) error {
 	now := time.Now().UTC()
 	amzDate := now.Format("20060102T150405Z")
 	date := now.Format("20060102")
-	payloadHash := hashPayload(req)
+	payloadHash := req.Header.Get("X-Amz-Content-Sha256")
+	if payloadHash == "" {
+		payloadHash = hashPayload(req)
+	}
 
 	req.Header.Set("Host", req.URL.Host)
 	req.Header.Set("X-Amz-Date", amzDate)
@@ -383,6 +385,21 @@ func (s *Storage) sign(req *http.Request) error {
 	signature := hex.EncodeToString(hmacSHA256(signingKey, stringToSign))
 	req.Header.Set("Authorization", "AWS4-HMAC-SHA256 Credential="+s.accessKeyID+"/"+scope+", SignedHeaders="+signedHeaders+", Signature="+signature)
 	return nil
+}
+
+type hashingReader struct {
+	reader io.Reader
+	hash   hash.Hash
+	size   int64
+}
+
+func (r *hashingReader) Read(p []byte) (int, error) {
+	n, err := r.reader.Read(p)
+	if n > 0 {
+		_, _ = r.hash.Write(p[:n])
+		r.size += int64(n)
+	}
+	return n, err
 }
 
 func hashPayload(req *http.Request) string {

--- a/lazystorage/s3/s3_test.go
+++ b/lazystorage/s3/s3_test.go
@@ -26,6 +26,9 @@ func TestStoragePutOpenListDeleteAndURL(t *testing.T) {
 				w.WriteHeader(http.StatusOK)
 				return
 			}
+			if r.Header.Get("X-Amz-Content-Sha256") != unsignedPayload {
+				t.Errorf("X-Amz-Content-Sha256 = %q, want %q", r.Header.Get("X-Amz-Content-Sha256"), unsignedPayload)
+			}
 			data, _ := io.ReadAll(r.Body)
 			objects[key] = string(data)
 			w.WriteHeader(http.StatusOK)
@@ -69,8 +72,12 @@ func TestStoragePutOpenListDeleteAndURL(t *testing.T) {
 	if err := storage.EnsureBucket(ctx); err != nil {
 		t.Fatal(err)
 	}
-	if _, _, err := storage.Put(ctx, "assets/app.js", strings.NewReader("console.log('ok');"), lazystorage.ContentType{Value: "text/javascript"}); err != nil {
+	info, _, err := storage.Put(ctx, "assets/app.js", strings.NewReader("console.log('ok');"), lazystorage.ContentType{Value: "text/javascript"})
+	if err != nil {
 		t.Fatal(err)
+	}
+	if info.Size != 18 || info.Checksum != "sha256:16ba942cc0730b9c1416eb532c015b5d26bf8419618e315abe2544b87ae63a16" {
+		t.Fatalf("Put info = %#v", info)
 	}
 	opened, _, err := storage.Open(ctx, "assets/app.js")
 	if err != nil {
@@ -88,12 +95,12 @@ func TestStoragePutOpenListDeleteAndURL(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	info, err := iterator.Next()
+	listed, err := iterator.Next()
 	if err != nil {
 		t.Fatal(err)
 	}
-	if info.Key != "assets/app.js" {
-		t.Fatalf("listed key = %q", info.Key)
+	if listed.Key != "assets/app.js" {
+		t.Fatalf("listed key = %q", listed.Key)
 	}
 	resolved, _, err := storage.URL(ctx, "assets/app.js")
 	if err != nil {


### PR DESCRIPTION
### Motivation
- `Storage.Put` previously buffered the entire caller-supplied `io.Reader` with `io.ReadAll`, and SigV4 signing could read the body again, enabling memory exhaustion for large uploads. 
- The change prevents attacker-controlled large uploads from causing excessive in-memory allocations while preserving upload metadata reporting.

### Description
- Stop pre-reading the full body in `Put` and stream the caller-provided `io.Reader` directly in the HTTP request.  
- Use the SigV4 marker `X-Amz-Content-Sha256: UNSIGNED-PAYLOAD` for streamed uploads and make `sign` prefer that header before falling back to `hashPayload`.  
- Add an on-the-fly `hashingReader` that wraps the provided `io.Reader` to compute SHA-256 and byte `size` while the stream is consumed, and return those values in the `lazystorage.Info`.  
- Extend `lazystorage/s3` tests to assert the `X-Amz-Content-Sha256` header is set to `UNSIGNED-PAYLOAD` and that `Put` returns the expected `Size` and `Checksum` for the uploaded data.

### Testing
- Ran `go test ./lazystorage/s3` and the package tests passed.  
- Ran the full test suite with `go test ./...` and all tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4076bc7bf48328b4e9890bde05b8a4)