### PR TITLE
Limit JSONL log record size

### DIFF
--- a/lazyfiles/log_repository.go
+++ b/lazyfiles/log_repository.go
@@ -12,6 +12,8 @@ import (
 	"time"
 )
 
+const maxLogRecordBytes = 1 << 20
+
 // LogRepository stores file metadata in an append-only JSONL log.
 type LogRepository struct {
 	mu        sync.RWMutex
@@ -125,6 +127,7 @@ func (r *LogRepository) replay() error {
 	defer file.Close()
 
 	scanner := bufio.NewScanner(file)
+	scanner.Buffer(make([]byte, 0, 64*1024), maxLogRecordBytes)
 	for scanner.Scan() {
 		var event logEvent
 		if err := json.Unmarshal(scanner.Bytes(), &event); err != nil {
@@ -156,6 +159,9 @@ func (r *LogRepository) append(event logEvent) error {
 	data, err := json.Marshal(event)
 	if err != nil {
 		return err
+	}
+	if len(data) > maxLogRecordBytes {
+		return fmt.Errorf("lazyfiles: log record is %d bytes, exceeds %d byte limit", len(data), maxLogRecordBytes)
 	}
 	if _, err := file.Write(append(data, '\n')); err != nil {
 		return err

--- a/lazyfiles/log_repository_test.go
+++ b/lazyfiles/log_repository_test.go
@@ -3,6 +3,7 @@ package lazyfiles
 import (
 	"context"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -31,5 +32,44 @@ func TestLogRepositoryReplaysEvents(t *testing.T) {
 	}
 	if len(locations) != 1 || locations[0].Key != "card.txt" {
 		t.Fatalf("locations = %#v, want card.txt", locations)
+	}
+}
+
+func TestLogRepositoryReplaysLargeRecordWithinLimit(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "files.log.jsonl")
+	repo, err := NewLogRepository(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	filename := strings.Repeat("a", 70*1024)
+	file := File{ID: "file-1", Filename: filename}
+	location := Location{FileID: "file-1", Storage: "local", Key: "card.txt", Role: RolePrimary, Status: StatusActive}
+	if _, _, err := repo.Put(context.Background(), file, location); err != nil {
+		t.Fatal(err)
+	}
+
+	reopened, err := NewLogRepository(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, _, _, err := reopened.Find(context.Background(), Query{ID: "file-1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Filename != filename {
+		t.Fatalf("Filename length = %d, want %d", len(got.Filename), len(filename))
+	}
+}
+
+func TestLogRepositoryRejectsOversizedRecord(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "files.log.jsonl")
+	repo, err := NewLogRepository(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	file := File{ID: "file-1", Filename: strings.Repeat("a", maxLogRecordBytes)}
+	location := Location{FileID: "file-1", Storage: "local", Key: "card.txt", Role: RolePrimary, Status: StatusActive}
+	if _, _, err := repo.Put(context.Background(), file, location); err == nil {
+		t.Fatal("Put succeeded, want oversized log record error")
 	}
 }

--- a/lazymedia/log_repository.go
+++ b/lazymedia/log_repository.go
@@ -12,6 +12,8 @@ import (
 	"time"
 )
 
+const maxLogRecordBytes = 1 << 20
+
 // LogRepository stores variant metadata in an append-only JSONL log.
 type LogRepository struct {
 	mu       sync.RWMutex
@@ -105,6 +107,7 @@ func (r *LogRepository) replay() error {
 	defer file.Close()
 
 	scanner := bufio.NewScanner(file)
+	scanner.Buffer(make([]byte, 0, 64*1024), maxLogRecordBytes)
 	for scanner.Scan() {
 		var event logEvent
 		if err := json.Unmarshal(scanner.Bytes(), &event); err != nil {
@@ -132,6 +135,9 @@ func (r *LogRepository) append(event logEvent) error {
 	data, err := json.Marshal(event)
 	if err != nil {
 		return err
+	}
+	if len(data) > maxLogRecordBytes {
+		return fmt.Errorf("lazymedia: log record is %d bytes, exceeds %d byte limit", len(data), maxLogRecordBytes)
 	}
 	if _, err := file.Write(append(data, '\n')); err != nil {
 		return err

--- a/lazymedia/log_repository_test.go
+++ b/lazymedia/log_repository_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -37,5 +38,53 @@ func TestLogRepositoryReplaysVariants(t *testing.T) {
 	}
 	if string(variant.Spec) != string(spec) {
 		t.Fatalf("Spec = %s, want %s", variant.Spec, spec)
+	}
+}
+
+func TestLogRepositoryReplaysLargeRecordWithinLimit(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "variants.log.jsonl")
+	repo, err := NewLogRepository(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	spec := json.RawMessage(`{"payload":"` + strings.Repeat("a", 70*1024) + `"}`)
+	if _, _, err := repo.SaveVariant(context.Background(), Variant{
+		SourceFileID: "source-1",
+		VariantKey:   "og",
+		Spec:         spec,
+		OutputFileID: "output-1",
+		Status:       StatusReady,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	reopened, err := NewLogRepository(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	variant, _, err := reopened.FindVariant(context.Background(), "source-1", "og")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(variant.Spec) != string(spec) {
+		t.Fatalf("Spec length = %d, want %d", len(variant.Spec), len(spec))
+	}
+}
+
+func TestLogRepositoryRejectsOversizedRecord(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "variants.log.jsonl")
+	repo, err := NewLogRepository(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	spec := json.RawMessage(`{"payload":"` + strings.Repeat("a", maxLogRecordBytes) + `"}`)
+	if _, _, err := repo.SaveVariant(context.Background(), Variant{
+		SourceFileID: "source-1",
+		VariantKey:   "og",
+		Spec:         spec,
+		OutputFileID: "output-1",
+		Status:       StatusReady,
+	}); err == nil {
+		t.Fatal("SaveVariant succeeded, want oversized log record error")
 	}
 }


### PR DESCRIPTION
### Motivation
- Prevent attacker-controlled large filenames/metadata/specs/errors from poisoning the append-only JSONL logs and causing repository reopen failures due to `bufio.Scanner`'s default 64 KiB token limit.

### Description
- Introduce a `maxLogRecordBytes` limit (1 MiB) in both `lazyfiles` and `lazymedia` log repositories.
- Increase the replay scanner capacity with `scanner.Buffer(..., maxLogRecordBytes)` so records larger than 64 KiB but within the limit can be replayed safely.
- Validate marshaled JSONL output and return an error if `len(data) > maxLogRecordBytes` to prevent persisting oversized records.
- Add regression tests that assert large-but-bounded records replay correctly and that oversized records are rejected in both repositories.

### Testing
- Ran `go test ./...` and all packages passed, including the new tests added for `lazyfiles` and `lazymedia`.
- New tests added: `TestLogRepositoryReplaysLargeRecordWithinLimit` and `TestLogRepositoryRejectsOversizedRecord` in both `lazyfiles/log_repository_test.go` and `lazymedia/log_repository_test.go`, and they succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4075fd9fbc832888c60155fdc22ab9)