### PR TITLE
Set safe default timeouts for lazyapp servers

### DIFF
--- a/lazyapp/README.md
+++ b/lazyapp/README.md
@@ -48,14 +48,20 @@ default server shortcut; it uses `ADDR`, then `PORT`, then
 control plane and either mounts it into the app server when the addresses match
 or starts a second server when the address differs. It also sets the server base
 context to `app.Context`, so request contexts include the dependencies
-initialized by `lazyapp.New`.
+initialized by `lazyapp.New`. The shortcut configures conservative HTTP
+timeouts (`ReadHeaderTimeout`, `ReadTimeout`, `WriteTimeout`, and
+`IdleTimeout`) to protect directly exposed apps from slow clients.
 
-When using your own `http.Server`, set `BaseContext` manually:
+When using your own `http.Server`, set `BaseContext` and HTTP timeouts manually:
 
 ```go
 server := &http.Server{
-    Addr:    ":3000",
-    Handler: app,
+    Addr:              ":3000",
+    Handler:           app,
+    ReadHeaderTimeout: 5 * time.Second,
+    ReadTimeout:       30 * time.Second,
+    WriteTimeout:      30 * time.Second,
+    IdleTimeout:       120 * time.Second,
     BaseContext: func(_ net.Listener) context.Context {
         return app.Context
     },

--- a/lazyapp/app.go
+++ b/lazyapp/app.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"net/http"
 	"strings"
+	"time"
 
 	"golazy.dev/lazyassets"
 	"golazy.dev/lazycache"
@@ -61,6 +62,13 @@ type App struct {
 }
 
 var afterDraw = func(*lazyroutes.Scope) {}
+
+const (
+	defaultReadHeaderTimeout = 5 * time.Second
+	defaultReadTimeout       = 30 * time.Second
+	defaultWriteTimeout      = 30 * time.Second
+	defaultIdleTimeout       = 120 * time.Second
+)
 
 func MustSub(fsys fs.FS, dir string) func() (fs.FS, error) {
 	sub, err := fs.Sub(fsys, dir)
@@ -243,8 +251,10 @@ func (app *App) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 // ListenAndServe starts the app server on ADDR, PORT, or 127.0.0.1:3000.
 //
 // It installs app.Context as the server base context, so every request context
-// includes the dependencies initialized by New. When using a custom http.Server,
-// set BaseContext to return app.Context.
+// includes the dependencies initialized by New. It also configures conservative
+// HTTP timeouts so slow clients cannot hold connections open indefinitely. When
+// using a custom http.Server, set BaseContext to return app.Context and configure
+// ReadHeaderTimeout, ReadTimeout, WriteTimeout, and IdleTimeout for your app.
 func (app *App) ListenAndServe() error {
 	appAddr := listenAddr()
 	controlAddr, controlAddrSet := controlPlaneListenAddr()
@@ -323,8 +333,12 @@ func (app *App) handlersForListen(appAddr string, controlAddr string, controlAdd
 
 func (app *App) newServer(addr string, handler http.Handler) *http.Server {
 	return &http.Server{
-		Addr:    addr,
-		Handler: handler,
+		Addr:              addr,
+		Handler:           handler,
+		ReadHeaderTimeout: defaultReadHeaderTimeout,
+		ReadTimeout:       defaultReadTimeout,
+		WriteTimeout:      defaultWriteTimeout,
+		IdleTimeout:       defaultIdleTimeout,
 		BaseContext: func(_ net.Listener) context.Context {
 			return app.Context
 		},

--- a/lazyapp/app_test.go
+++ b/lazyapp/app_test.go
@@ -1076,6 +1076,33 @@ func TestAppMountsPrometheusMetricsFromOTELEnv(t *testing.T) {
 	}
 }
 
+func TestNewServerConfiguresTimeoutsAndBaseContext(t *testing.T) {
+	type contextKey struct{}
+	app := New(Config{
+		Dependencies: func(deps *lazydeps.Scope) error {
+			deps.SetContext(context.WithValue(deps.Context(), contextKey{}, "initialized"))
+			return nil
+		},
+	})
+
+	server := app.newServer("127.0.0.1:0", app)
+	if server.ReadHeaderTimeout != defaultReadHeaderTimeout {
+		t.Fatalf("ReadHeaderTimeout = %s, want %s", server.ReadHeaderTimeout, defaultReadHeaderTimeout)
+	}
+	if server.ReadTimeout != defaultReadTimeout {
+		t.Fatalf("ReadTimeout = %s, want %s", server.ReadTimeout, defaultReadTimeout)
+	}
+	if server.WriteTimeout != defaultWriteTimeout {
+		t.Fatalf("WriteTimeout = %s, want %s", server.WriteTimeout, defaultWriteTimeout)
+	}
+	if server.IdleTimeout != defaultIdleTimeout {
+		t.Fatalf("IdleTimeout = %s, want %s", server.IdleTimeout, defaultIdleTimeout)
+	}
+	if got := server.BaseContext(nil).Value(contextKey{}); got != "initialized" {
+		t.Fatalf("base context value = %v, want initialized", got)
+	}
+}
+
 func TestControlPlaneListenAddr(t *testing.T) {
 	t.Setenv("CONTROL_PLANE_ADDR", "9090")
 	reloadEnvironmentForTest(t)


### PR DESCRIPTION
### Motivation
- The `App.ListenAndServe` helper created `http.Server` instances without any timeouts, allowing slow clients to hold connections and goroutines indefinitely (Slowloris-style DoS).

### Description
- Add conservative default timeout constants and apply them in `App.newServer` by setting `ReadHeaderTimeout`, `ReadTimeout`, `WriteTimeout`, and `IdleTimeout`.
- Preserve existing behavior of installing `app.Context` as the server `BaseContext` so request contexts still include initialized dependencies.
- Update `lazyapp` documentation and `README.md` to note the timeout configuration and show example timeout settings for custom `http.Server` usage.
- Add a unit test `TestNewServerConfiguresTimeoutsAndBaseContext` that asserts the new server has the expected timeout values and base context value.

### Testing
- Ran `go test ./lazyapp` which passed successfully.
- Ran `go test ./...` (all packages) which completed successfully with no failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a407a6939f08328a8383dd807d6951e)