### PR TITLE
Secure default session cookie attributes

### DIFF
--- a/lazysession/sessions_test.go
+++ b/lazysession/sessions_test.go
@@ -40,8 +40,11 @@ func TestFlashes(t *testing.T) {
 
 	store := NewCookieStore([]byte("secret-key"))
 
-	if store.Options.SameSite != http.SameSiteNoneMode {
-		t.Fatalf("cookie store error: default same site is not set to None")
+	if store.Options.SameSite != http.SameSiteLaxMode {
+		t.Fatalf("cookie store error: default same site is not set to Lax")
+	}
+	if !store.Options.HttpOnly {
+		t.Fatal("cookie store error: default HttpOnly is not enabled")
 	}
 
 	// Round 1 ----------------------------------------------------------------
@@ -72,8 +75,8 @@ func TestFlashes(t *testing.T) {
 		t.Fatal("No cookies. Header:", hdr)
 	}
 
-	if !strings.Contains(cookies[0], "SameSite=None") || !strings.Contains(cookies[0], "Secure") {
-		t.Fatal("Set-Cookie does not contains SameSite=None with Secure, cookie string:", cookies[0])
+	if !strings.Contains(cookies[0], "SameSite=Lax") || !strings.Contains(cookies[0], "Secure") || !strings.Contains(cookies[0], "HttpOnly") {
+		t.Fatal("Set-Cookie does not contain SameSite=Lax with Secure and HttpOnly, cookie string:", cookies[0])
 	}
 
 	if _, err = store.Get(req, "session:key"); err.Error() != "sessions: invalid character in cookie name: session:key" {

--- a/lazysession/store.go
+++ b/lazysession/store.go
@@ -56,8 +56,9 @@ func NewCookieStore(keyPairs ...[]byte) *CookieStore {
 		Options: &Options{
 			Path:     "/",
 			MaxAge:   86400 * 30,
-			SameSite: http.SameSiteNoneMode,
+			SameSite: http.SameSiteLaxMode,
 			Secure:   true,
+			HttpOnly: true,
 		},
 	}
 


### PR DESCRIPTION
### Motivation
- The `CookieStore` default options created session cookies with `SameSite=None` and `HttpOnly=false`, which makes cookies usable in cross-site requests and readable by JavaScript, increasing CSRF and XSS risk.
- Framework integration (`lazyapp`) installs the session manager when `Sessions` are enabled, so those unsafe defaults affected applications by default.
- Change the defaults to safer, browser-restrictive settings to reduce accidental insecure deployments.

### Description
- Change the `NewCookieStore` defaults in `lazysession/store.go` to set `SameSite: http.SameSiteLaxMode` and `HttpOnly: true` while preserving `Secure: true` and existing behavior. 
- Update the session test in `lazysession/sessions_test.go` to assert the new defaults and to check the emitted `Set-Cookie` header contains `SameSite=Lax`, `Secure`, and `HttpOnly`.
- Preserve the existing `applyOptions` and store construction behavior so custom `Options` continue to override the defaults.

### Testing
- Ran `go test ./lazysession ./lazyapp` and the targeted package tests completed successfully. 
- Ran the full test suite with `go test ./...` and all packages passed. 
- Ran `git diff --check` to ensure no formatting or error issues and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a407a6384848328a6aa262337e4cccc)