### PR TITLE
Limit response buffer memory growth

### DIFF
--- a/lazydispatch/response_buffer.go
+++ b/lazydispatch/response_buffer.go
@@ -5,7 +5,11 @@ import (
 	"net/http"
 )
 
+const defaultResponseBufferLimit = 1 << 20
+
 // ResponseBuffer delays sending a response until the downstream handler returns.
+// Responses larger than the in-memory limit are streamed to the client to avoid
+// unbounded memory growth.
 func ResponseBuffer() Middleware {
 	return responseBuffer{}
 }
@@ -35,12 +39,14 @@ type BufferedResponseWriter struct {
 	status int
 	sent   bool
 	stream bool
+	limit  int
 }
 
 func NewBufferedResponseWriter(w http.ResponseWriter) *BufferedResponseWriter {
 	return &BufferedResponseWriter{
 		writer: w,
 		header: make(http.Header),
+		limit:  defaultResponseBufferLimit,
 	}
 }
 
@@ -54,6 +60,13 @@ func (w *BufferedResponseWriter) Write(data []byte) (int, error) {
 	}
 	if !w.sent {
 		w.WriteHeader(http.StatusOK)
+	}
+	if w.limit > 0 && w.body.Len()+len(data) > w.limit {
+		stream, err := w.startStream(w.status, true)
+		if err != nil {
+			return 0, err
+		}
+		return stream.Write(data)
 	}
 	return w.body.Write(data)
 }
@@ -109,6 +122,10 @@ func (w *BufferedResponseWriter) Unwrap() http.ResponseWriter {
 // StartStream commits the buffered headers and lets callers write directly to
 // the wrapped response writer.
 func (w *BufferedResponseWriter) StartStream(status int) (http.ResponseWriter, error) {
+	return w.startStream(status, false)
+}
+
+func (w *BufferedResponseWriter) startStream(status int, flushBuffered bool) (http.ResponseWriter, error) {
 	if status == 0 {
 		status = http.StatusOK
 	}
@@ -116,10 +133,18 @@ func (w *BufferedResponseWriter) StartStream(status int) (http.ResponseWriter, e
 		w.writer.Header().Del(key)
 		w.writer.Header()[key] = append([]string(nil), values...)
 	}
+	var buffered []byte
+	if flushBuffered {
+		buffered = append([]byte(nil), w.body.Bytes()...)
+	}
 	w.body.Reset()
 	w.status = status
 	w.sent = true
 	w.stream = true
 	w.writer.WriteHeader(status)
-	return w.writer, nil
+	if len(buffered) == 0 {
+		return w.writer, nil
+	}
+	_, err := w.writer.Write(buffered)
+	return w.writer, err
 }

--- a/lazydispatch/response_buffer_test.go
+++ b/lazydispatch/response_buffer_test.go
@@ -89,3 +89,29 @@ func TestResponseBufferCanStartStreaming(t *testing.T) {
 		t.Fatalf("body = %q, want %q", got, want)
 	}
 }
+
+func TestResponseBufferStreamsWhenLimitExceeded(t *testing.T) {
+	firstWriteReached := false
+	handler := ResponseBuffer().Handler(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("X-Test", "large")
+		_, _ = w.Write(make([]byte, defaultResponseBufferLimit))
+		_, _ = w.Write([]byte("x"))
+		firstWriteReached = true
+	}))
+
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, httptest.NewRequest(http.MethodGet, "/", nil))
+
+	if !firstWriteReached {
+		t.Fatal("handler did not finish")
+	}
+	if response.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", response.Code, http.StatusOK)
+	}
+	if got, want := response.Body.Len(), defaultResponseBufferLimit+1; got != want {
+		t.Fatalf("body length = %d, want %d", got, want)
+	}
+	if response.Header().Get("X-Test") != "large" {
+		t.Fatalf("X-Test = %q, want large", response.Header().Get("X-Test"))
+	}
+}


### PR DESCRIPTION
### Motivation
- The global `ResponseBuffer` previously buffered entire responses in memory with no size limit, enabling memory exhaustion when large static or dynamic responses are produced.  
- The buffer also prevented normal streaming semantics by withholding writes until handler return.

### Description
- Add a default in-memory limit `const defaultResponseBufferLimit = 1 << 20` and a `limit` field on `BufferedResponseWriter`, initialized in `NewBufferedResponseWriter`.  
- Make `Write` switch to streaming when `w.body.Len()+len(data) > w.limit`, using an internal `startStream(status, flushBuffered bool)` helper that flushes already-buffered bytes only when the limit-driven transition happens.  
- Preserve the explicit `StartStream` API by delegating to `startStream(status, false)`, so callers that explicitly start streaming do not automatically re-flush buffered bytes.  
- Add a regression test `TestResponseBufferStreamsWhenLimitExceeded` in `lazydispatch/response_buffer_test.go` to validate limit-driven streaming behavior.

### Testing
- Ran `go test ./...` and all packages passed successfully.  
- Ran `go test ./lazydispatch ./lazyroutes` during iteration to validate the buffered/streaming behavior and the new `TestResponseBufferStreamsWhenLimitExceeded` test, and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a407b7cd44083289ed77bb0140ccd8e)